### PR TITLE
Refresh page from server upon submit

### DIFF
--- a/index.html
+++ b/index.html
@@ -270,6 +270,7 @@
 
             $('#submit').click(function(e) {
                 e.preventDefault();
+                location.reload(true)
                 var login = $("#login").val(),
                 password = $('#password').val(),
                 sharedsecret = $('#sharedsecret').val(),

--- a/index.html
+++ b/index.html
@@ -270,7 +270,6 @@
 
             $('#submit').click(function(e) {
                 e.preventDefault();
-                location.reload(true)
                 var login = $("#login").val(),
                 password = $('#password').val(),
                 sharedsecret = $('#sharedsecret').val(),
@@ -337,6 +336,7 @@
                 xmlString = xmlString.replace('{{onDemandRules}}', onDemandRules)
                 console.log(xmlString);
                 download('vpn.mobileconfig', xmlString);
+                location.reload(true)
             })
         });
     </script>


### PR DESCRIPTION
This is in response to @luc-ass / Issue #6. 

Adding line 273 refreshes the page (from the server, not from the cache) when the "Generate" button is pressed. This resets the form values, preventing web browsers from retaining cached information and producing duplicate profiles (even when the form input is changed by the user). 

I have tested creating numerous profiles with this change, and all have been produced as intended. After your testing, I believe this bug can be resolved.